### PR TITLE
Change implementation from `prepend` to `UnboundMethod`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ B.call # => 42
 ```
 
 ## Difference with other gems
-Memery is very similar to [Memoist](https://github.com/matthewrudy/memoist). The difference is that it doesn't override methods, instead it uses Ruby 2 `Module.prepend` feature. This approach is cleaner and it allows subclasses' methods to work properly: if you redefine a memoized method in a subclass, it's not memoized by default, but you can memoize it normally (without using awkward `identifier: ` argument) and it will just work:
+Memery is very similar to [Memoist](https://github.com/matthewrudy/memoist). The difference is that it doesn't create additional prefixed methods, instead it uses `UnboundMethod` as local variable. This approach is cleaner and it allows subclasses' methods to work properly: if you redefine a memoized method in a subclass, it's not memoized by default, but you can memoize it normally (without using awkward `identifier: ` argument) and it will just work:
 
 ```ruby
 class A

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -163,7 +163,9 @@ RSpec.describe Memery do
     end
 
     specify do
-      expect { klass }.to raise_error(ArgumentError, /Method foo is not defined/)
+      expect { klass }.to raise_error(
+        NameError, /undefined method `foo' for class `#<Class:0x\w+>'/
+      )
     end
   end
 end


### PR DESCRIPTION
`prepend` pollutes `Module#ancestors`:

```ruby
module Foo
end

class Bar
  prepend Foo
end

class Baz < Bar
  prepend Foo
end

Baz.ancestors # => [Foo, Baz, Foo, Bar, Object, Kernel, BasicObject]
```