### PR TITLE
Add `.ruby-version` file to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+.ruby-version
 
 # rspec failure tracking
 .rspec_status


### PR DESCRIPTION
It's common file for rbenv, RVM, RuboCop, etc.