### PR TITLE
Optimize speed and memory for cached values returns

### DIFF
--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -44,16 +44,15 @@ module Memery
             return super(*args, &block)
           end
 
+          key = "#{method_name}_#{mod_id}"
+
+          store = @_memery_memoized_values&.[](key)
+
+          return store[args] if store&.key?(args)
+
           @_memery_memoized_values ||= {}
-
-          key = [method_name, mod_id].join("_").to_sym
-          store = @_memery_memoized_values[key] ||= {}
-
-          if store.key?(args)
-            store[args]
-          else
-            store[args] = super(*args)
-          end
+          @_memery_memoized_values[key] ||= {}
+          @_memery_memoized_values[key][args] = super(*args)
         end
 
         send(visibility, method_name)


### PR DESCRIPTION
```ruby

require 'bundler/setup'
Bundler.setup

require 'benchmark'
require 'benchmark/ips'
require 'benchmark/memory'

puts '```ruby'
puts File.read(__FILE__).gsub("\t", '  ')
puts '```'
puts
puts '### Output'
puts
puts '```'

require_relative 'lib/memery'
require_relative 'lib/memery_new'

class Foo
  class << self
    include Memery
    include MemeryNew

    def base_find(char)
      ('a'..'k').find { |letter| letter == char }
    end

    memoize def find_old(char)
      base_find(char)
    end

    memoize_new def find_new(char)
      base_find(char)
    end
  end
end

def memery_old
  Foo.find_old('d')
end

def memery_new
  Foo.find_new('d')
end

def test
  exit unless p (((p memery_old) == (p memery_new)))
end

test

Benchmark.ips do |x|
  x.report('memery_old') { memery_old }
  x.report('memery_new') { memery_new }

  x.compare!
end

Benchmark.memory do |x|
  x.report('memery_old') { 100.times { memery_old } }
  x.report('memery_new') { 100.times { memery_new } }

  x.compare!
end

puts '```'
```

```
"d"
"d"
true
Warming up --------------------------------------
          memery_old    24.664k i/100ms
          memery_new    31.363k i/100ms
Calculating -------------------------------------
          memery_old    285.113k (± 5.7%) i/s -      1.431M in   5.034622s
          memery_new    360.540k (± 6.2%) i/s -      1.819M in   5.067173s

Comparison:
          memery_new:   360540.0 i/s
          memery_old:   285112.6 i/s - 1.26x  slower

Calculating -------------------------------------
          memery_old    32.800k memsize (     0.000  retained)
                       500.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)
          memery_new    16.000k memsize (     0.000  retained)
                       400.000  objects (     0.000  retained)
                         3.000  strings (     0.000  retained)

Comparison:
          memery_new:      16000 allocated
          memery_old:      32800 allocated - 2.05x more
```