### PR TITLE
Fix memoization with Hash-like objects as parameters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     memery (1.3.0)
+      warning (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -77,6 +78,7 @@ GEM
     tins (1.24.0)
       sync
     unicode-display_width (1.6.1)
+    warning (1.0.0)
 
 PLATFORMS
   ruby

--- a/memery.gemspec
+++ b/memery.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "warning", "~> 1.0"
+
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "benchmark-memory"
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
After adding `**kwargs` due to warnings in Ruby 2.7,
Hash-like parameters (with `#to_hash` method) convert to Hash
while passed in dynamically created by Memery method.
For example, instances of `Sequel::Model`.

Found Ruby bug: https://bugs.ruby-lang.org/issues/14909

So, changes will be in Ruby 2.8.

And for now we can:

1.  Use `**(;{})` as the additional parameter at method call, what is ugly.
2.  Define memoized methods with `eval` and exactly expected arguments,
    what is dangerous (eval is evil).
3.  Suppress warnings about keyword arguments until here are no failing tests.

I've chose the 3th.