### PR TITLE
Fix memoization with Hash-like objects as parameters

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     memery (1.3.0)
+      ruby2_keywords (~> 0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -65,6 +66,7 @@ GEM
     rubocop-rspec (1.37.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
+    ruby2_keywords (0.0.2)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)

--- a/memery.gemspec
+++ b/memery.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "ruby2_keywords", "~> 0.0.2"
+
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "benchmark-memory"
   spec.add_development_dependency "bundler"

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -164,6 +164,24 @@ RSpec.describe Memery do
       expect(values).to eq([[1, 1], [1, 1], [1, 2]])
       expect(CALLS).to eq([[1, 1], [1, 2]])
     end
+
+    context "receiving Hash-like object" do
+      let(:object_class) do
+        Struct.new(:first_name, :last_name) do
+          # For example, Sequel models have such implicit coercion,
+          # which conflicts with `**kwargs`.
+          alias_method :to_hash, :to_h
+        end
+      end
+
+      let(:object) { object_class.new("John", "Wick") }
+
+      specify do
+        values = [ a.m_args(1, object), a.m_args(1, object), a.m_args(1, 2) ]
+        expect(values).to eq([[1, object], [1, object], [1, 2]])
+        expect(CALLS).to eq([[1, object], [1, 2]])
+      end
+    end
   end
 
   context "method with keyword args" do


### PR DESCRIPTION
After adding `**kwargs` due to warnings in Ruby 2.7,
Hash-like parameters (with `#to_hash` method) convert to Hash
while passed in dynamically created by Memery method.
For example, instances of `Sequel::Model`.

Found Ruby bug: https://bugs.ruby-lang.org/issues/14909

So, changes will be in Ruby 2.8.

And for now we can:

1.  Use `**(;{})` as the additional parameter at method call, what is ugly.
2.  Define memoized methods with `eval` and exactly expected arguments,
    what is dangerous (eval is evil).
3.  Suppress warnings about keyword arguments until here are no failing tests.

First, I've chose the 3th.

But then Jeremy Evans suggest to use `ruby2_keywords`. So, here we're!

Additional line of code offensed RuboCop (method length),
so I was forced to refactor method definition.