### PR TITLE
Fix compatibility with AS Concern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- Fix compatibility with `ActiveSupport::Concern`. (revert [#23])
+
 ## [1.3.0] - 2020-02-10
 ### Added
 - Allow memoization after including module with Memery. ([@AlexWayfer]) [#23]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 
 ### Fixed
-- Fix compatibility with `ActiveSupport::Concern`. (revert [#23])
+- Fix compatibility with `ActiveSupport::Concern`. ([@tycooon] and [@AlexWayfer]) [#26]
 
 ## [1.3.0] - 2020-02-10
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (5.2.4.2)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     ast (2.4.0)
     benchmark-ips (2.7.2)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
     coderay (1.1.2)
+    concurrent-ruby (1.1.6)
     coveralls (0.8.23)
       json (>= 1.8, < 3)
       simplecov (~> 0.16.1)
@@ -20,10 +26,13 @@ GEM
       tins (~> 1.6)
     diff-lcs (1.3)
     docile (1.3.2)
+    i18n (1.8.2)
+      concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.4)
     json (2.3.0)
     memory_profiler (0.9.14)
     method_source (0.9.2)
+    minitest (5.14.0)
     parallel (1.19.1)
     parser (2.7.0.2)
       ast (~> 2.4.0)
@@ -76,14 +85,18 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.0.1)
+    thread_safe (0.3.6)
     tins (1.24.0)
       sync
+    tzinfo (1.2.6)
+      thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 5.0)
   benchmark-ips
   benchmark-memory
   bundler

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -6,20 +6,15 @@ require "memery/version"
 
 module Memery
   class << self
+    def included(base)
+      base.extend(ClassMethods)
+      base.include(InstanceMethods)
+    end
+
     def monotonic_clock
       Process.clock_gettime(Process::CLOCK_MONOTONIC)
     end
   end
-
-  module ModuleMethods
-    def included(base)
-      base.extend(ClassMethods)
-      base.include(InstanceMethods)
-      base.extend ModuleMethods if base.instance_of?(Module)
-    end
-  end
-
-  extend ModuleMethods
 
   module ClassMethods
     def memoize(method_name, condition: nil, ttl: nil)
@@ -32,16 +27,14 @@ module Memery
       return false unless defined?(@_memery_module)
 
       @_memery_module.method_defined?(method_name) ||
-        @_memery_module.private_method_defined?(method_name)
+      @_memery_module.private_method_defined?(method_name)
     end
 
     private
 
     def prepend_memery_module!
       return if defined?(@_memery_module)
-      @_memery_module = Module.new do
-        extend MemoizationModule
-      end
+      @_memery_module = Module.new { extend MemoizationModule }
       prepend @_memery_module
     end
 

--- a/memery.gemspec
+++ b/memery.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "ruby2_keywords", "~> 0.0.2"
 
+  spec.add_development_dependency "activesupport", "~> 5.0"
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "benchmark-memory"
   spec.add_development_dependency "bundler"

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -247,6 +247,28 @@ RSpec.describe Memery do
     end
   end
 
+  context "module with self.included method defined" do
+    subject(:c) { C.new }
+
+    before { C.include(some_mixin) }
+
+    let(:some_mixin) do
+      Module.new do
+        extend ActiveSupport::Concern
+        include Memery
+
+        included do
+          attr_accessor :a
+        end
+      end
+    end
+
+    it "doesn't override existing method" do
+      c.a = 15
+      expect(c.a).to eq(15)
+    end
+  end
+
   context "class method with args" do
     subject(:d) { D }
 

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -89,6 +89,11 @@ end
 
 class C
   include M
+
+  memoize def m_class
+    CALLS << __method__
+    __method__
+  end
 end
 
 class D
@@ -244,6 +249,14 @@ RSpec.describe Memery do
       values = [c.m, c.m, c.m]
       expect(values).to eq([:m, :m, :m])
       expect(CALLS).to eq([:m])
+    end
+
+    context "memoization in class" do
+      specify do
+        values = [c.m_class, c.m_class, c.m_class]
+        expect(values).to eq([:m_class, :m_class, :m_class])
+        expect(CALLS).to eq([:m_class])
+      end
     end
   end
 

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -89,11 +89,6 @@ end
 
 class C
   include M
-
-  memoize def m_class
-    CALLS << __method__
-    __method__
-  end
 end
 
 class D
@@ -249,14 +244,6 @@ RSpec.describe Memery do
       values = [c.m, c.m, c.m]
       expect(values).to eq([:m, :m, :m])
       expect(CALLS).to eq([:m])
-    end
-
-    context "memoization in class" do
-      specify do
-        values = [c.m_class, c.m_class, c.m_class]
-        expect(values).to eq([:m_class, :m_class, :m_class])
-        expect(CALLS).to eq([:m_class])
-      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
 SimpleCov.start
 
 require "memery"
+require "active_support/concern"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
Fixes the following exception when using Memery in a `ActiveSupport::Concern` module:

```
ArgumentError:
  wrong number of arguments (given 0, expected 1)
# ./lib/memery.rb:15:in `included'
```