### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,23 +7,24 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (5.2.4.2)
+    activesupport (6.0.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+      zeitwerk (~> 2.2)
     ast (2.4.0)
     benchmark-ips (2.7.2)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
     coderay (1.1.2)
     concurrent-ruby (1.1.6)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
+    coveralls_reborn (0.15.1)
+      json (~> 2.1)
+      simplecov (~> 0.18.1)
+      term-ansicolor (~> 1.6)
+      thor (>= 0.20.3, < 2.0)
+      tins (~> 1.16)
     diff-lcs (1.3)
     docile (1.3.2)
     i18n (1.8.2)
@@ -31,76 +32,79 @@ GEM
     jaro_winkler (1.5.4)
     json (2.3.0)
     memory_profiler (0.9.14)
-    method_source (0.9.2)
+    method_source (1.0.0)
     minitest (5.14.0)
     parallel (1.19.1)
-    parser (2.7.0.2)
+    parser (2.7.1.1)
       ast (~> 2.4.0)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
-    rack (2.1.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rack (2.2.2)
     rainbow (3.0.0)
     rake (13.0.1)
+    rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
       rspec-mocks (~> 3.9.0)
     rspec-core (3.9.1)
       rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.0)
+    rspec-expectations (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    rubocop (0.79.0)
+    rubocop (0.81.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
       rainbow (>= 2.2.2, < 4.0)
+      rexml
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-config-umbrellio (0.79.0.68)
-      rubocop (= 0.79.0)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-config-umbrellio (0.81.0.78)
+      rubocop (= 0.81.0)
       rubocop-performance (= 1.5.2)
-      rubocop-rails (= 2.4.1)
-      rubocop-rspec (= 1.37.1)
+      rubocop-rails (= 2.5.0)
+      rubocop-rspec (= 1.38.1)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.4.1)
+    rubocop-rails (2.5.0)
+      activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.37.1)
+    rubocop-rspec (1.38.1)
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     ruby2_keywords (0.0.2)
-    simplecov (0.16.1)
+    simplecov (0.18.5)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.0.1)
     thread_safe (0.3.6)
-    tins (1.24.0)
+    tins (1.24.1)
       sync
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    unicode-display_width (1.6.1)
+    unicode-display_width (1.7.0)
+    zeitwerk (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (~> 5.0)
+  activesupport
   benchmark-ips
   benchmark-memory
   bundler
-  coveralls
+  coveralls_reborn
   memery!
   pry
   rake
@@ -109,4 +113,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/memery.gemspec
+++ b/memery.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "ruby2_keywords", "~> 0.0.2"
 
-  spec.add_development_dependency "activesupport", "~> 5.0"
+  spec.add_development_dependency "activesupport"
   spec.add_development_dependency "benchmark-ips"
   spec.add_development_dependency "benchmark-memory"
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "coveralls"
+  spec.add_development_dependency "coveralls_reborn"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
1. If we have the `Gemfile.lock` in repository — why do we need for versions locks in `gemspec`?
2. There are outdated dependencies anyway, but I don't know why and left them.
3. Unmaintained `coveralls` replaced with `coveralls_reborn` fork.