### PR TITLE
Update CHANGELOG for 1.4.1 & link CHANGELOG in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [1.4.1] - 2021-06-16
+- Under-the-hood refactor & optimizations. ([@tycooon]) [bc503f3]
+
 ## [1.4.0] - 2021-03-15
 ### Fixed
 - Fix compatibility with `ActiveSupport::Concern`. ([@tycooon] and [@AlexWayfer]) [#26]
@@ -43,7 +46,8 @@
 [1.2.0]: https://github.com/tycooon/memery/compare/v1.1.0...v1.2.0
 [1.3.0]: https://github.com/tycooon/memery/compare/v1.2.0...v1.3.0
 [1.4.0]: https://github.com/tycooon/memery/compare/v1.3.0...v1.4.0
-[Unreleased]: https://github.com/tycooon/memery/compare/v1.4.0...HEAD
+[1.4.1]: https://github.com/tycooon/memery/compare/v1.4.0...v1.4.1
+[Unreleased]: https://github.com/tycooon/memery/compare/v1.4.1...HEAD
 
 [@tycooon]: https://github.com/tycooon
 [@AlexWayfer]: https://github.com/AlexWayfer
@@ -60,3 +64,4 @@
 [#23]: https://github.com/tycooon/memery/pull/23
 [#25]: https://github.com/tycooon/memery/pull/25
 [#26]: https://github.com/tycooon/memery/pull/26
+[bc503f3]: https://github.com/tycooon/memery/commit/bc503f36103a71245aa47aeb30225a48fb39438e

--- a/memery.gemspec
+++ b/memery.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "A gem for memoization."
   spec.description   = "Memery is a gem for memoization."
   spec.homepage      = "https://github.com/tycooon/memery"
+  spec.changelog_uri = "https://github.com/tycooon/memery/blob/master/CHANGELOG.md"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|


### PR DESCRIPTION
The gemspec link will add a link to rubygems.org as it does [here](https://rubygems.org/gems/invoker)