### PR TITLE
allow `memoize` to take multiple method names

### DIFF
--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -35,10 +35,12 @@ module Memery
   extend ModuleMethods
 
   module ClassMethods
-    def memoize(method_name, condition: nil, ttl: nil)
+    def memoize(*method_names, condition: nil, ttl: nil)
       prepend_memery_module!
-      define_memoized_method!(method_name, condition: condition, ttl: ttl)
-      method_name
+      method_names.each do |method_name|
+        define_memoized_method!(method_name, condition: condition, ttl: ttl)
+      end
+      method_names.length > 1 ? method_names : method_names.first
     end
 
     def memoized?(method_name)

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -157,11 +157,7 @@ RSpec.describe Memery do
   let(:unmemoized_class) do
     Class.new do
       include Memery
-
-      [:a, :b, :m, :n, :x, :y].each do |name|
-        define_method(name) do
-        end
-      end
+      attr_reader :a, :b, :m, :n, :x, :y
     end
   end
 

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -406,13 +406,6 @@ RSpec.describe Memery do
       values = [h.x, h.y, h.x, h.y]
       expect(values).to eq([:x, :y, :x, :y])
       expect(CALLS).to eq([:x, :y])
-
-      allow(Process).to receive(:clock_gettime).with(Process::CLOCK_MONOTONIC)
-        .and_wrap_original { |m, *args| m.call(*args) + 5 }
-
-      later_values = [h.x, h.x, h.y, h.x, h.y, h.y]
-      expect(later_values).to eq([:x, :x, :y, :x, :y, :y])
-      expect(CALLS).to eq([:x, :y, :x, :y])
     end
 
     specify do

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -134,6 +134,19 @@ class G
   macro memoize def g; end
 end
 
+class H
+  include Memery
+
+  [:a, :b, :m, :n, :x, :y].each do |name|
+    define_method(name) do
+      CALLS << name
+      name
+    end
+  end
+
+  memoize :m, :n
+  memoize :x, :y, ttl: 3
+end
 
 RSpec.describe Memery do
   subject(:a) { A.new }
@@ -141,7 +154,7 @@ RSpec.describe Memery do
   before { CALLS.clear }
   before { B_CALLS.clear }
 
-  let(:h_nomemo_class) do
+  let(:unmemoized_class) do
     Class.new do
       include Memery
 
@@ -381,14 +394,7 @@ RSpec.describe Memery do
   end
 
   describe "with multiple methods" do
-    let(:h_class) do
-      Class.new(h_nomemo_class) do
-        memoize :m, :n
-        memoize :x, :y, ttl: 3
-      end
-    end
-
-    let(:h) { h_class.new }
+    let(:h) { H.new }
 
     specify do
       values = [h.m, h.n, h.m, h.n]
@@ -409,23 +415,22 @@ RSpec.describe Memery do
       expect(CALLS).to eq([:x, :y, :x, :y])
     end
 
-
     specify do
-      expect(h_nomemo_class.memoize(:x, :y, ttl: 3)).to eq([:x, :y])
+      expect(unmemoized_class.memoize(:x, :y, ttl: 3)).to eq([:x, :y])
     end
   end
 
   describe ".memoize return value" do
     specify do
-      expect(h_nomemo_class.memoize(:x)).to eq(:x)
-      expect(h_nomemo_class.memoize(:m, ttl: 3)).to eq(:m)
-      expect(h_nomemo_class.memoize(:a, condition: -> { 1 == 2 })).to eq(:a)
+      expect(unmemoized_class.memoize(:x)).to eq(:x)
+      expect(unmemoized_class.memoize(:m, ttl: 3)).to eq(:m)
+      expect(unmemoized_class.memoize(:a, condition: -> { 1 == 2 })).to eq(:a)
     end
 
     specify do
-      expect(h_nomemo_class.memoize(:x, :y)).to eq([:x, :y])
-      expect(h_nomemo_class.memoize(:m, :n, ttl: 3)).to eq([:m, :n])
-      expect(h_nomemo_class.memoize(:a, :b, condition: -> { 1 == 2 })).to eq([:a, :b])
+      expect(unmemoized_class.memoize(:x, :y)).to eq([:x, :y])
+      expect(unmemoized_class.memoize(:m, :n, ttl: 3)).to eq([:m, :n])
+      expect(unmemoized_class.memoize(:a, :b, condition: -> { 1 == 2 })).to eq([:a, :b])
     end
   end
 

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -160,8 +160,6 @@ RSpec.describe Memery do
 
       [:a, :b, :m, :n, :x, :y].each do |name|
         define_method(name) do
-          CALLS << name
-          name
         end
       end
     end


### PR DESCRIPTION
# Purpose
I'm performing the upgrade to ruby-3 on a large rails project, and we used Memoist *heavily*. Memoist hasn't updated to support memoizing with keyword arguments in ruby 3 yet, and it looks like it might be quite difficult to do so - there have been outstanding tickets for roughly that feature for years now.

Swapping Memery in instead has been *mostly* seamless, but its lack of support for `memoize :foo, :bar, :baz` is forcing updates to several hundred files (some of our engineers disliked `memoize def foo`, because they felt it was too "java-ey").

# Original Internal Patch

I initially just wrote a prepend-patch for my own project to support it:

```
# frozen_string_literal: true

module Memery
  module PluralSupportingClassMethods
    def memoize(*method_names, **kwargs)
      method_names.each do |method_name|
        super(method_name, **kwargs)
      end
    end
  end
end

Memery::ClassMethods.send(:prepend, Memery::PluralSupportingClassMethods)
```

And I'm happy to continue to use that.. but I figured I'd check if you were interested in adopting the change upstream.

# Specs
The code change is fairly trivial, but I didn't feel like the existing test-suite structure made it easy to exercise the change - let me know if you have a preference for test structure here I should update to match (or feel free to take the PR and just rewrite it as you prefer. I have the time, but I know communication is frequently more work than coding).