### PR TITLE
Add initializer support method for object shape optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ a.users {}
 
 However, this solution is kind of hacky.
 
+## Object Shape Optimization
+
+In Ruby 3.2, a new optimization was introduced that relies on tracking "object shape", and has negative interactions with dynamically added instance variables (introduced after initialization-time). See [here](https://bugs.ruby-lang.org/issues/18776) for details, or [here](https://railsatscale.com/2023-10-24-memoization-pattern-and-object-shapes/) for an explanation of the relevance, but fundamentally Memery has substantial advantages over standard memoization techniques here - it introduces only _one_ new instance variable after initialization (`@_memery_memoized_values`). For particularly performance-critical classes however, you may wish to reduce that to zero; if so, you can call `setup_memery_cache!` in the initializer of your class, and it will set the instance variable before the object shape is determined.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/tycooon/memery.

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -115,6 +115,13 @@ module Memery
   end
 
   module InstanceMethods
+    # This method is not _functionally necessary_, but if called in the
+    # initializer of a class, it allows that class to avoid any issue with the
+    # "object shape optimization" introduced in Ruby 3.2.
+    def setup_memery_cache!
+      @_memery_memoized_values = {}
+    end
+
     def clear_memery_cache!
       @_memery_memoized_values = {}
     end

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -148,6 +148,14 @@ class H
   memoize :x, :y, ttl: 3
 end
 
+class I
+  include Memery
+
+  def initialize
+    setup_memery_cache!
+  end
+end
+
 RSpec.describe Memery do
   subject(:a) { A.new }
 
@@ -473,6 +481,14 @@ RSpec.describe Memery do
       let(:object) { M }
 
       include_examples "works correctly"
+    end
+  end
+
+  describe "#setup_memery_cache!" do
+    let(:i) { I.new }
+
+    specify do
+      expect(i).to be_instance_variable_defined("@_memery_memoized_values")
     end
   end
 end


### PR DESCRIPTION
Ruby 3.2 introduced a performance optimization that relies on observing and tracking "object shape" - see [here](https://railsatscale.com/2023-10-24-memoization-pattern-and-object-shapes/) for an explanation. Memery is already better than every other memoization pattern anyone actually uses, since there's only _one_ dynamically created instance variable for all of the memoized values, but people worry about the potential impact of heavy memoization on their applications (and I do memoize _all the things_).

So here's an extra method `setup_memery_cache!` that can optionally be called in an initializer and just sets the instance variable up - really people could just call `clear_memery_cache!` and have the same effect, but that seems less clear than having something actually intended for use in this way.

Probably suffices to fix #43, though I'll let @jrochkind make that call?

### Usage

```
class MySuperPerformanceCriticalClass
  include Memery

  def initialize
    setup_memery_cache!
  end

  memoize def calculate
    do_other_stuff
  end
end
```