### PR TITLE
Clear memery cache for specific method

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ a.memoized?(:call) # => true
 a.memoized?(:execute) # => false
 ```
 
+Clear memery cache for specific method:
+
+```ruby
+class A
+  include Memery
+
+  memoize def call
+    puts "calculating"
+    42
+  end
+end
+
+a = A.new
+
+a.call # outputs "calculating" and returns 42
+a.clear_memery_cache(:call)
+a.call # outputs "calculating" and returns 42
+```
+
 ## Difference with other gems
 Memery is very similar to [Memoist](https://github.com/matthewrudy/memoist). The difference is that it doesn't override methods, instead it uses Ruby 2 `Module.prepend` feature. This approach is cleaner (for example you are able to inspect the original method body using `method(:x).super_method.source`) and it allows subclasses' methods to work properly: if you redefine a memoized method in a subclass, it's not memoized by default, but you can memoize it normally (without using awkward `identifier: ` argument) and it will just work:
 

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -118,5 +118,20 @@ module Memery
     def clear_memery_cache!
       @_memery_memoized_values = {}
     end
+
+    def clear_memery_cache(method_name)
+      store = @_memery_memoized_values
+      return unless store&.any?
+
+      memoization_klass = Memery::ClassMethods.const_get(:MemoizationModule)
+
+      self.class.ancestors.each do |klass|
+        next unless klass.is_a?(memoization_klass)
+        method_key = "#{method_name}_#{klass.object_id}"
+        store.each_key do |key|
+          store.delete(key) if key == method_key || (key.is_a?(Array) && key.first == method_key)
+        end
+      end
+    end
   end
 end

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -179,6 +179,21 @@ RSpec.describe Memery do
     end
   end
 
+  context "flushing specific cache key" do
+    let(:h) { H.new }
+
+    specify do
+      m_values = [ h.m, h.m ]
+      n_values = [ h.n, h.n ]
+      h.clear_memery_cache(:m)
+      m_values << h.m
+      n_values << h.n
+      expect(m_values).to eq([:m, :m, :m])
+      expect(n_values).to eq([:n, :n, :n])
+      expect(CALLS).to eq([:m, :n, :m])
+    end
+  end
+
   context "method with args" do
     specify do
       values = [ a.m_args(1, 1), a.m_args(1, 1), a.m_args(1, 2) ]
@@ -260,6 +275,17 @@ RSpec.describe Memery do
       expect(values).to eq([100, 100, 100])
       expect(CALLS).to eq([[1, 2]])
       expect(B_CALLS).to eq([[1, 1], [1, 2]])
+    end
+
+    context "clear_memery_cache clears cache for ancestors" do
+      specify do
+        values = [ b.m_args(1, 5), b.m_args(1, 5) ]
+        b.clear_memery_cache(:m_args)
+        values << b.m_args(1, 5)
+        expect(values).to eq([100, 100, 100])
+        expect(CALLS).to eq([[1, 2], [1, 2]])
+        expect(B_CALLS).to eq([[1, 5], [1, 5]])
+      end
     end
   end
 


### PR DESCRIPTION
Hey, I adore this gem, it simplifies things a lot! I wish it's integrated into ruby itself!

However I found that it lacks a feature to clear cache for specific method..

I've added a method `clear_memery_cache(method_name)` to address this.