### PR TITLE
Drop dependency on `ruby2_keywords`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     memery (1.5.0)
-      ruby2_keywords (~> 0.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -88,7 +87,6 @@ GEM
     rubocop-sequel (0.3.4)
       rubocop (~> 1.0)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)

--- a/memery.gemspec
+++ b/memery.gemspec
@@ -21,6 +21,4 @@ Gem::Specification.new do |spec|
     f.match(%r{^(test|spec|features)/})
   end
   spec.require_paths = ["lib"]
-
-  spec.add_runtime_dependency "ruby2_keywords", "~> 0.0.2"
 end


### PR DESCRIPTION
The gem requires Ruby >= 2.7, which have these methods by default.