### PR TITLE
Bump GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: ${{ matrix.ruby }}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - uses: ruby/setup-ruby@v1
       with:
@@ -26,6 +26,6 @@ jobs:
 
     - run: bundle exec rake
 
-    - uses: coverallsapp/github-action@v1.1.2
+    - uses: coverallsapp/github-action@v2
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
There are a few deprecation warnings as a result of using these older versions, coverage might not work at all anymore? Seems stuck on my other PRs.

![image](https://github.com/tycooon/memery/assets/14981592/a740bec7-203d-4438-a47b-445da9412f69)
