### PR TITLE
Improve performance of memoized methods with arguments by ~50%

### DIFF
--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -80,7 +80,7 @@ module Memery
           end
 
           cache_store = (@_memery_memoized_values ||= {})
-          cache_key = original_arity.zero? ? method_key : [method_key, *args]
+          cache_key = original_arity.zero? ? method_key : [method_key, *args].hash
           cache = cache_store[cache_key]
 
           return cache.result if cache&.fresh?(ttl)


### PR DESCRIPTION
Based on the information in this twitter thread, I believe we can improve the hash-lookup times of memoized method calls with arguments _substantially_, with only a small change.

https://threadreaderapp.com/thread/1831412716533379235.html

Running benchmark.rb prior to change:

```
Warming up --------------------------------------
        test_no_args   526.602k i/100ms
Calculating -------------------------------------
        test_no_args      5.172M (± 1.8%) i/s -     26.330M in   5.092880s
Calculating -------------------------------------
        test_no_args     4.000k memsize (     0.000  retained)
                       100.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
Warming up --------------------------------------
      test_with_args   221.217k i/100ms
Calculating -------------------------------------
      test_with_args      2.203M (± 5.6%) i/s -     11.061M in   5.045789s
Calculating -------------------------------------
      test_with_args    12.000k memsize (     0.000  retained)
                       300.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```

And after:
```
Warming up --------------------------------------
        test_no_args   529.096k i/100ms
Calculating -------------------------------------
        test_no_args      5.247M (± 1.3%) i/s -     26.455M in   5.042306s
Calculating -------------------------------------
        test_no_args     4.000k memsize (     0.000  retained)
                       100.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
Warming up --------------------------------------
      test_with_args   331.604k i/100ms
Calculating -------------------------------------
      test_with_args      3.471M (± 0.8%) i/s -     17.575M in   5.064376s
Calculating -------------------------------------
      test_with_args    12.000k memsize (     0.000  retained)
                       300.000  objects (     0.000  retained)
                         0.000  strings (     0.000  retained)
```

The `test_no_args` case is unaffected (as expected) but the `test_with_args` case sees a very significant speedup.