### PR TITLE
Allow objects with memoized values to be marshaled/unmarshaled across Ruby processes

### DIFF
--- a/benchmark.rb
+++ b/benchmark.rb
@@ -32,6 +32,10 @@ class Foo
     memoize def find_new(char)
       base_find(char)
     end
+
+    memoize def find_optional(*)
+      base_find("z")
+    end
   end
 end
 
@@ -43,12 +47,24 @@ def test_with_args
   Foo.find_new("d")
 end
 
+def test_empty_args
+  Foo.find_optional
+end
+
 Benchmark.ips do |x|
   x.report("test_no_args") { test_no_args }
 end
 
 Benchmark.memory do |x|
   x.report("test_no_args") { 100.times { test_no_args } }
+end
+
+Benchmark.ips do |x|
+  x.report("test_empty_args") { test_empty_args }
+end
+
+Benchmark.memory do |x|
+  x.report("test_empty_args") { 100.times { test_empty_args } }
 end
 
 Benchmark.ips do |x|

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -39,6 +39,22 @@ class Foo
   end
 end
 
+class FooNoHash
+  class << self
+    include Memery
+
+    self.memery_use_hashed_arguments = false
+
+    def base_find(char)
+      ("a".."k").find { |letter| letter == char }
+    end
+
+    memoize def find_new(char)
+      base_find(char)
+    end
+  end
+end
+
 def test_no_args
   Foo.find_z
 end
@@ -49,6 +65,10 @@ end
 
 def test_empty_args
   Foo.find_optional
+end
+
+def test_with_args_no_hash
+  FooNoHash.find_new("d")
 end
 
 Benchmark.ips do |x|
@@ -73,6 +93,14 @@ end
 
 Benchmark.memory do |x|
   x.report("test_with_args") { 100.times { test_with_args } }
+end
+
+Benchmark.ips do |x|
+  x.report("test_with_args_no_hash") { test_with_args_no_hash }
+end
+
+Benchmark.memory do |x|
+  x.report("test_with_args_no_hash") { 100.times { test_with_args_no_hash } }
 end
 
 puts "```"

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -39,22 +39,6 @@ class Foo
   end
 end
 
-class FooNoHash
-  class << self
-    include Memery
-
-    self.memery_use_hashed_arguments = false
-
-    def base_find(char)
-      ("a".."k").find { |letter| letter == char }
-    end
-
-    memoize def find_new(char)
-      base_find(char)
-    end
-  end
-end
-
 def test_no_args
   Foo.find_z
 end
@@ -65,10 +49,6 @@ end
 
 def test_empty_args
   Foo.find_optional
-end
-
-def test_with_args_no_hash
-  FooNoHash.find_new("d")
 end
 
 Benchmark.ips do |x|
@@ -95,12 +75,14 @@ Benchmark.memory do |x|
   x.report("test_with_args") { 100.times { test_with_args } }
 end
 
+Memery.use_hashed_arguments = false
 Benchmark.ips do |x|
-  x.report("test_with_args_no_hash") { test_with_args_no_hash }
+  x.report("test_with_args_no_hash") { test_with_args }
 end
 
 Benchmark.memory do |x|
-  x.report("test_with_args_no_hash") { 100.times { test_with_args_no_hash } }
+  x.report("test_with_args_no_hash") { 100.times { test_with_args } }
 end
+Memery.use_hashed_arguments = true
 
 puts "```"

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -72,6 +72,7 @@ module Memery
         end
       end
 
+      # rubocop:disable Metrics/MethodLength
       def define_memoized_method!(klass, method_name, condition: nil, ttl: nil)
         original_visibility = method_visibility(klass, method_name)
 
@@ -101,6 +102,7 @@ module Memery
         ruby2_keywords(method_name)
         send(original_visibility, method_name)
       end
+      # rubocop:enable Metrics/MethodLength
 
       private
 

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -69,8 +69,6 @@ module Memery
       end
 
       def define_memoized_method!(klass, method_name, condition: nil, ttl: nil)
-        method_key = "#{method_name}_#{object_id}"
-
         original_visibility = method_visibility(klass, method_name)
         original_arity = klass.instance_method(method_name).arity
 
@@ -80,7 +78,7 @@ module Memery
           end
 
           cache_store = (@_memery_memoized_values ||= {})
-          cache_key = original_arity.zero? ? method_key : [method_key, *args].hash
+          cache_key = original_arity.zero? ? method_name : [method_name, *args].hash
           cache = cache_store[cache_key]
 
           return cache.result if cache&.fresh?(ttl)

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -84,8 +84,12 @@ module Memery
           end
 
           cache_store = (@_memery_memoized_values ||= {})
-          cache_key = args.empty? ? method_name : [method_name, *args]
-          cache_key = cache_key.hash if use_hashed_arguments && !args.empty?
+          cache_key = if args.empty?
+                        method_name
+                      else
+                        key_parts = [method_name, *args]
+                        use_hashed_arguments ? key_parts.hash : key_parts
+                      end
           cache = cache_store[cache_key]
 
           return cache.result if cache&.fresh?(ttl)

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -78,7 +78,12 @@ module Memery
           end
 
           cache_store = (@_memery_memoized_values ||= {})
-          cache_key = original_arity.zero? ? method_name : [method_name, *args].hash
+          cache_key =
+            if original_arity.zero? || args.empty?
+              method_name
+            else
+              [method_name, *args].hash
+            end
           cache = cache_store[cache_key]
 
           return cache.result if cache&.fresh?(ttl)

--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -74,6 +74,9 @@ module Memery
 
       # rubocop:disable Metrics/MethodLength
       def define_memoized_method!(klass, method_name, condition: nil, ttl: nil)
+        # Include a suffix in the method key to differentiate between methods of the same name
+        # being memoized throughout a class inheritance hierarchy
+        method_key = "#{method_name}_#{klass.name || object_id}"
         original_visibility = method_visibility(klass, method_name)
 
         define_method(method_name) do |*args, &block|
@@ -83,9 +86,9 @@ module Memery
 
           cache_store = (@_memery_memoized_values ||= {})
           cache_key = if args.empty?
-                        method_name
+                        method_key
                       else
-                        key_parts = [method_name, *args]
+                        key_parts = [method_key, *args]
                         Memery.use_hashed_arguments ? key_parts.hash : key_parts
                       end
           cache = cache_store[cache_key]

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -263,6 +263,27 @@ RSpec.describe Memery do
     end
   end
 
+  context "anonymous inherited class" do
+    let(:anonymous_class) do
+      Class.new(A) do
+        memoize def m_args(x, y)
+          B_CALLS << [x, y]
+          super(1, 2)
+          100
+        end
+      end
+    end
+
+    subject(:b) { anonymous_class.new }
+
+    specify do
+      values = [ b.m_args(1, 1), b.m_args(1, 2), b.m_args(1, 1) ]
+      expect(values).to eq([100, 100, 100])
+      expect(CALLS).to eq([[1, 2]])
+      expect(B_CALLS).to eq([[1, 1], [1, 2]])
+    end
+  end
+
   context "module" do
     subject(:c) { C.new }
 

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -153,6 +153,7 @@ RSpec.describe Memery do
 
   before { CALLS.clear }
   before { B_CALLS.clear }
+  before { Memery.use_hashed_arguments = true }
 
   let(:unmemoized_class) do
     Class.new do
@@ -354,6 +355,26 @@ RSpec.describe Memery do
       values = [e.m, e.m, e.m]
       expect(values).to eq([:m, :m, :m])
       expect(CALLS).to eq([:m])
+    end
+  end
+
+  context "without hashed arguments" do
+    before { Memery.use_hashed_arguments = false }
+
+    context "methods without args" do
+      specify do
+        values = [ a.m, a.m_nil, a.m, a.m_nil ]
+        expect(values).to eq([:m, nil, :m, nil])
+        expect(CALLS).to eq([:m, nil])
+      end
+    end
+
+    context "method with args" do
+      specify do
+        values = [ a.m_args(1, 1), a.m_args(1, 1), a.m_args(1, 2) ]
+        expect(values).to eq([[1, 1], [1, 1], [1, 2]])
+        expect(CALLS).to eq([[1, 1], [1, 2]])
+      end
     end
   end
 


### PR DESCRIPTION
Hi there!  This pull request makes 2 main changes:

1. It improves the performance by 50% of calls to methods that accept arguments, but didn't receive any
2. It allows objects that were marshaled with memoized values to be unmarshaled in another Ruby process

I'm happy to break this apart into 2 separate PRs, but the performance improvement is mostly a side effect of other changes.

## Performance improvements

The performance improvement here is mostly straightforward.  Consider the current implementation for generating cache keys: https://github.com/tycooon/memery/blob/9bcae5e2d3d17b27c8be21b18fc53db69ae1b407/lib/memery.rb#L83

In this code, we will only use `method_key` if the `arity` is zero.  However, if we have a method like so:

```ruby
def value(*args)
  args
end
```

...then the `arity` is non-zero and we'll be required to generate a hash for the cache key.  This isn't necessary because a call with no arguments should be treated identical to a call to a method that accepts no arguments.  By making this change, we can improve performance by ~50%.  Benchmarks below:

<details>
  <summary>Benchmark before</summary>

  ```
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
  Warming up --------------------------------------
          test_no_args   302.263k i/100ms
  Calculating -------------------------------------
          test_no_args      3.049M (± 0.3%) i/s  (328.01 ns/i) -     15.415M in   5.056509s
  Calculating -------------------------------------
          test_no_args     4.000k memsize (     0.000  retained)
                         100.000  objects (     0.000  retained)
                           0.000  strings (     0.000  retained)
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
  Warming up --------------------------------------
       test_empty_args   212.775k i/100ms
  Calculating -------------------------------------
       test_empty_args      2.132M (± 0.3%) i/s  (469.04 ns/i) -     10.852M in   5.089886s
  Calculating -------------------------------------
       test_empty_args    12.000k memsize (    80.000  retained)
                         300.000  objects (     2.000  retained)
                           0.000  strings (     0.000  retained)
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
  Warming up --------------------------------------
        test_with_args   180.110k i/100ms
  Calculating -------------------------------------
        test_with_args      1.800M (± 0.3%) i/s  (555.52 ns/i) -      9.006M in   5.002773s
  Calculating -------------------------------------
        test_with_args    12.000k memsize (    80.000  retained)
                         300.000  objects (     2.000  retained)
                           0.000  strings (     0.000  retained)
  ```
</details>

<details>
  <summary>Benchmark after</summary>

  ```
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
  Warming up --------------------------------------
          test_no_args   332.647k i/100ms
  Calculating -------------------------------------
          test_no_args      3.296M (± 3.7%) i/s  (303.42 ns/i) -     16.632M in   5.054779s
  Calculating -------------------------------------
          test_no_args     4.000k memsize (     0.000  retained)
                         100.000  objects (     0.000  retained)
                           0.000  strings (     0.000  retained)
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
  Warming up --------------------------------------
       test_empty_args   327.994k i/100ms
  Calculating -------------------------------------
       test_empty_args      3.273M (± 0.7%) i/s  (305.54 ns/i) -     16.400M in   5.011001s
  Calculating -------------------------------------
       test_empty_args     4.000k memsize (     0.000  retained)
                         100.000  objects (     0.000  retained)
                           0.000  strings (     0.000  retained)
  ruby 3.3.5 (2024-09-03 revision ef084cc8f4) [x86_64-linux]
  Warming up --------------------------------------
        test_with_args   185.707k i/100ms
  Calculating -------------------------------------
        test_with_args      1.854M (± 0.5%) i/s  (539.31 ns/i) -      9.285M in   5.007838s
  Calculating -------------------------------------
        test_with_args    12.000k memsize (    80.000  retained)
                         300.000  objects (     2.000  retained)
                           0.000  strings (     0.000  retained)
  ```
</details>

## Marshal improvements

In our application, we store ActiveRecord objects in Memcached, including the state for memoized fields.  When we moved to `memery`, we found that these memoized fields weren't being read from correctly when unmarshaling them from Memcached.  There are currently 2 pieces of code that cause issues:

https://github.com/tycooon/memery/blob/9bcae5e2d3d17b27c8be21b18fc53db69ae1b407/lib/memery.rb#L72

....and:

https://github.com/tycooon/memery/blob/9bcae5e2d3d17b27c8be21b18fc53db69ae1b407/lib/memery.rb#L83

In these 2 pieces of code, the cache keys generated for a method call can be different across Ruby processes:
* The `object_id` of the prepended module will be different based on the order in which classes are loaded and code is executed
* The `hash` of an object will be different (introduced in https://github.com/tycooon/memery/pull/50)

In this PR, I'm proposing that we solve this by:
* Exclude the `object_id` of the prepended module from the cache key.  I can't figure out what the use case is for this, so I'm just removing it altogether
* Make the hashing of arguments *optional*

By making these changes, I can do the following:

```ruby
class Foo
  include Memery

  self.memery_use_hashed_arguments = false

  def base_find(char)
    ("a".."k").find { |letter| letter == char }
  end

  memoize def find_new(char)
    puts "finding #{char}"
    base_find(char)
  end
end

irb> f = Foo.new
=> #<Foo:0x000056102107e360>
irb> f.find_new('a')
finding a
=> "a"
irb> f.find_new('a')
=> "a"
irb> Marshal.dump(f)
=> "\x04\bo:\bFoo\x06:\x1D@_memery_memoized_values{\x06[\a:\rfind_newI\"\x06a\x06:\x06ETS:3Memery::ClassMethods::MemoizationModule::Cache\a:\vresultI\"\x06a\x06;\bT:\ttimef\x1413717.190731299"
```

...then load that marshaled value into a separate Ruby process and retain the memoized values:

```ruby
irb> f = Marshal.load("\x04\bo:\bFoo\x06:\x1D@_memery_memoized_values{\x06[\a:\rfind_newI\"\x06a\x06:\x06ETS:3Memery::ClassMethods::MemoizationModule::Cache\a:\vresultI\"\x06a\x06;\bT:\ttimef\x1413717.190731299")
=> #<Foo:0x0000563ebfb517c0 @_memery_memoized_values={[:find_new, "a"]=>#<struct Memery::ClassMethods::MemoizationModule::Cache result="a", time=13717.190731299>}>
irb> f.find_new('a')
=> "a"
```

## Notes

* The last commit fixes a Rubocop failures on number of lines allow for a method definition.  Seems less readable to me, but feel free to make adjustments to the code style as needed!

Hope all of that makes sense!  Let me know what you think and whether you'd like me to split this out into multiple PRs.  Thanks!