### PR TITLE
Memoize can be a on its own line

### DIFF
--- a/lib/memery.rb
+++ b/lib/memery.rb
@@ -38,6 +38,10 @@ module Memery
 
   module ClassMethods
     def memoize(*method_names, condition: nil, ttl: nil)
+      if method_names.empty?
+        @_memery_memoize_next_method = { condition: condition, ttl: ttl }
+        return
+      end
       prepend_memery_module!
       method_names.each do |method_name|
         define_memoized_method!(method_name, condition: condition, ttl: ttl)
@@ -50,6 +54,15 @@ module Memery
 
       @_memery_module.method_defined?(method_name) ||
       @_memery_module.private_method_defined?(method_name)
+    end
+
+    def method_added(name)
+      super
+
+      return unless @_memery_memoize_next_method
+
+      memoize(name, **@_memery_memoize_next_method)
+      @_memery_memoize_next_method = nil
     end
 
     private

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -14,6 +14,12 @@ class A
     m_private
   end
 
+  memoize
+  def m_different_line
+    CALLS << :m_different_line
+    :m_different_line
+  end
+
   def not_memoized; end
 
   memoize def m_nil
@@ -78,6 +84,13 @@ module M
   memoize def m
     CALLS << :m
     :m
+  end
+
+  memoize
+
+  def m_different_line
+    CALLS << :m_different_line
+    :m_different_line
   end
 
   def not_memoized; end
@@ -480,6 +493,12 @@ RSpec.describe Memery do
         it { is_expected.to be true }
       end
 
+      context "memoize is on a different line" do
+        let(:method_name) { :m_different_line }
+
+        it { is_expected.to be true }
+      end
+
       context "private memoized method" do
         let(:method_name) { :m_private }
 
@@ -516,5 +535,7 @@ RSpec.describe Memery do
 
       include_examples "works correctly"
     end
+
+
   end
 end

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -535,7 +535,5 @@ RSpec.describe Memery do
 
       include_examples "works correctly"
     end
-
-
   end
 end

--- a/spec/memery_spec.rb
+++ b/spec/memery_spec.rb
@@ -183,6 +183,14 @@ RSpec.describe Memery do
     end
   end
 
+  context "methods without args memoize on new line" do
+    specify do
+      values = [ a.m_different_line, a.m_nil, a.m_different_line, a.m_nil ]
+      expect(values).to eq([:m_different_line, nil, :m_different_line, nil])
+      expect(CALLS).to eq([:m_different_line, nil])
+    end
+  end
+
   context "flushing cache" do
     specify do
       values = [ a.m, a.m ]
@@ -305,6 +313,12 @@ RSpec.describe Memery do
       values = [c.m, c.m, c.m]
       expect(values).to eq([:m, :m, :m])
       expect(CALLS).to eq([:m])
+    end
+
+    specify do
+      values = [c.m_different_line, c.m_different_line, c.m_different_line]
+      expect(values).to eq([:m_different_line, :m_different_line, :m_different_line])
+      expect(CALLS).to eq([:m_different_line])
     end
 
     context "memoization in class" do


### PR DESCRIPTION
This allows defining methods like:

```ruby
memoize
def foo
  "string"
end
```

This would previous not memoize the method.